### PR TITLE
create_basic-admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  
+  before_action :basic_auth, if: :production? 
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
   add_flash_types :success, :info, :warning, :danger
@@ -11,5 +11,17 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :avatar, :profile])
   end
-  
+
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
+
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -7,7 +7,10 @@ server '3.114.152.122', user: 'ec2-user', roles: %w{app db web}
 # server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
+server "3.114.152.122", user: "ec2-user", roles: %w{app db web}
 
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 
 
 # role-based syntax


### PR DESCRIPTION
# What
パスを入力しなければいけないBasic認証の導入

# Why
使うUserを限定して、安全性をはかるため